### PR TITLE
update blis to 1.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ annotated-types==0.7.0
 anyio==4.9.0
 appnope==0.1.4
 asttokens==3.0.0
-blis==1.2.1
+blis==1.3.0
 catalogue==2.0.10
 certifi==2025.1.31
 charset-normalizer==3.4.1


### PR DESCRIPTION
Previous blis package doesn't work on Python 3.13.0, but this newer version is backwards compatible